### PR TITLE
Bugfix urlloader in larch.utils.LangchainDocumentParser

### DIFF
--- a/larch/utils.py
+++ b/larch/utils.py
@@ -200,7 +200,7 @@ class LangchainDocumentParser:
         return self._split_text(docs)
 
     def parse_url(self, path: str) -> List[LangchainDocument]:
-        docs = self.url_loader_cls(urls=[path]).load()
+        docs = self.url_loader_cls([path]).load()
         return self._split_text(docs)
 
     def parse_txt(self, path: str) -> List[LangchainDocument]:


### PR DESCRIPTION
This removes `urls` argument to the object of `utils.LangchainDocumentParser.url_parser_cls` while loading urls.