### PR TITLE
Bugfix `larch.indexing.DocumentIndexer.as_langchain_retriever(...)`

### DIFF
--- a/larch/indexing/_base.py
+++ b/larch/indexing/_base.py
@@ -122,6 +122,6 @@ class DocumentIndexer(ABC):
 
     def as_langchain_retriever(self) -> Type[BaseRetriever]:
         # to avoid circular import
-        from .search.chains import DocumentIndexerAsRetriever
+        from ..search.chains import DocumentIndexerAsRetriever
 
         return DocumentIndexerAsRetriever(document_indexer=self)

--- a/larch/search/chains.py
+++ b/larch/search/chains.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import List, Type
+from typing import List
 
 from langchain.callbacks.manager import CallbackManagerForRetrieverRun
 from langchain.schema.retriever import BaseRetriever
@@ -10,7 +10,7 @@ from ..structures import Document, LangchainDocument
 
 
 class DocumentIndexerAsRetriever(BaseRetriever):
-    document_indexer: Type[DocumentIndexer]
+    document_indexer: DocumentIndexer
 
     def _get_relevant_documents(
         self,


### PR DESCRIPTION
This fixes `.as_langchain_retriever(...)` method in any DocumentIndexer.