### PR TITLE
Deprecate older SinequaDocumentIndexer in favor of new SinequaDocumen…

### DIFF
--- a/larch/indexing/indexers.py
+++ b/larch/indexing/indexers.py
@@ -11,7 +11,7 @@ from langchain.chains.base import Chain
 from langchain.chains.question_answering import load_qa_chain
 from langchain.schema.embeddings import Embeddings
 from langchain.text_splitter import TextSplitter
-from langchain.vectorstores import FAISS, Chroma, PGVector, VectorStore
+from langchain_community.vectorstores import FAISS, Chroma, PGVector, VectorStore
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from loguru import logger
 from pydantic import BaseModel

--- a/larch/indexing/sinequa.py
+++ b/larch/indexing/sinequa.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python3
 import ast
 from typing import Callable, Dict, List, Optional
+from warnings import warn
 
 from loguru import logger
 from pydantic import BaseModel
 from pynequa import AdvancedParams, QueryParams, Sinequa
 
+from ..retrievers import SinequaDocumentRetriever
 from ..structures import Document
 from ..utils import remove_duplicate_documents
 from ._base import DocumentIndexer
 
+DEPRECATION_MESSAGE = "`larch.indexing.SinequaDocumentIndexer` will be deprecated in favor of `larch.retrievers.SinequaDocumentRetriever` for larch version`>=0.1.0`"
+
 
 class SinequaDocumentIndexer(DocumentIndexer):
-    """
-    This uses Sinequa as document store to extract metadata
-    from the documents stored in Sinequa.
-    """
-
     # not recommended to change as it might break result parsing
     columns_to_surface = [
         "text",
@@ -38,90 +37,33 @@ class SinequaDocumentIndexer(DocumentIndexer):
         text_processor: Optional[Callable] = None,
         debug: bool = False,
     ) -> None:
+        logger.warning(DEPRECATION_MESSAGE)
+        warn(
+            DEPRECATION_MESSAGE,
+            DeprecationWarning,
+            2,
+        )
         super().__init__(
             docs=docs,
             text_processor=text_processor,
             debug=debug,
         )
 
-        self.sinequa = Sinequa.from_config(
-            cfg={
-                "base_url": base_url,
-                "access_token": auth_token,
-                "app_name": app_name,
-                "query_name": query_name,
-            },
+        self.retriever = SinequaDocumentRetriever(
+            base_url=base_url,
+            auth_token=auth_token,
+            app_name=app_name,
+            query_name=query_name,
+            collection=collection,
+            columns=columns,
+            debug=debug,
         )
-        self.columns = columns
-        self.collection = collection
-
-    def _parse_query_results(self, results) -> List[Document]:
-        """
-        This method parses query results from sinequa and returns
-        then in a document format as a list.
-
-        It will remove duplicate results while returning the document list.
-        """
-
-        if "ErrorCode" in results:
-            error_message = results["ErrorMessage"]
-            logger.error(error_message)
-            raise Exception(f"Error: {error_message}")
-
-        top_passages = results["topPassages"]["passages"]
-
-        documents = []
-        for passage in top_passages:
-            matching_text = passage["highlightedText"]
-            source = passage["recordId"].split("|")[1]
-            documents.append(
-                Document(
-                    text=matching_text,
-                    source=source,
-                    extras={
-                        "score": passage["score"],
-                        "location": passage["location"],
-                        "rlocation": passage["rlocation"],
-                        "record_id": passage["recordId"],
-                    },
-                ),
-            )
-
-        return remove_duplicate_documents(documents)
 
     def index_documents(self, paths: List[str]) -> Dict[str, BaseModel]:
         raise NotImplementedError
 
     def query(self, *args, **kwargs):
         raise NotImplementedError
-
-    def _query_vectorstore(
-        self,
-        params: QueryParams,
-        **kwargs,
-    ) -> List[Document]:
-        # if self.debug:
-        #     logger.debug(f"pynequa params :: {params}")
-        #     logger.debug(f"Generated Payload :: {params.generate_payload()}")
-        results = self.sinequa.search_query(params)
-        return self._parse_query_results(results)
-
-    def _build_pynequa_params(self, **kwargs) -> QueryParams:
-        collection = self.collection
-
-        params = QueryParams()
-        params.search_text = kwargs.get("query")
-        params.page = kwargs.get("page", 1)
-        params.page_size = kwargs.get("top_k", 5) * 2
-        params.additional_where_clause = kwargs.get("additional_where_clause")
-
-        advanced_params = kwargs.get("advanced") or kwargs.get("advanced_params")
-        if collection and not advanced_params:
-            advanced_params = dict(col_name="collection", col_value=collection)
-        params.advanced = AdvancedParams(**advanced_params)
-
-        params.debug = kwargs.get("debug") or self.debug
-        return params
 
     def query_vectorstore(
         self,
@@ -140,102 +82,4 @@ class SinequaDocumentIndexer(DocumentIndexer):
         Returns:
             List[Document]: Top k documents
         """
-        iterative_call = kwargs.get("iterative_call", False)
-        params = self._build_pynequa_params(query=query, top_k=top_k, **kwargs)
-
-        # search for documents
-        documents = self._query_vectorstore(params)
-
-        # if iterative_call is True
-        len_documents = len(documents)
-        if len_documents < top_k and iterative_call:
-            while len_documents < top_k:
-                params.page += 1
-
-                parsed_documents = self._query_vectorstore(params)
-                if len(parsed_documents) == 0:
-                    break
-
-                documents.extend(parsed_documents)
-                len_documents = len(documents)
-
-        return documents[:top_k]
-
-
-class SinequaSQLRetriever(SinequaDocumentIndexer):
-    def query_vectorstore(
-        self,
-        query: str,
-        top_k: int = 5,
-        **kwargs,
-    ) -> List[Document]:
-        """
-        This method queries Sinequa vector store to retrieve
-        top_k documents with embeddings for given query text
-        using direct SQL query.
-
-        Args:
-            query (str): Query string
-            top_k (int): Top k documents to surface
-            collection (str): Collection to search
-        Returns:
-            List[Document]: Top k documents
-        """
-
-        collection = (
-            self.collection or kwargs.get("collection") or kwargs.get("collection_name")
-        )
-        sql_query = self._generate_sql_query(query, collection, top_k)
-        if self.debug:
-            logger.debug(f"SQL Query :: {sql_query}")
-        results = self.sinequa.engine_sql(
-            sql=sql_query,
-            max_rows=top_k,
-        )
-        return self._parse_sql_results(results["Rows"])
-
-    def _generate_sql_query(
-        self,
-        query: str,
-        collection: str,
-        limit: int = 5,
-    ) -> str:
-        """
-        This method generates SQL query for Sinequa's SQL Engine
-
-        Args:
-            collection (str): Name of collection o query to
-            query (str): query text
-            limit (int): maximum number of results to return
-        Returns:
-            str : SQL query string
-        """
-        column_str = ",".join(self.columns)
-        return f"""SELECT {column_str} FROM index
-                        WHERE collection='{collection}'
-                        AND
-                        text contains '{query}'
-                        LIMIT {limit}"""
-
-    def _parse_sql_results(self, rows: List) -> List[Document]:
-        """ "
-        This method parses the string response from Sinequa into
-        list of Document objects.
-
-        Args:
-            rows (List): list of results from SQL engine
-        Returns:
-            [Document] : list of Document objects
-        """
-        documents = []
-        for row in rows:
-            embeddings = ast.literal_eval(row[1])[0]["v"]
-
-            documents.append(
-                Document(
-                    text=row[0],
-                    embeddings=embeddings,
-                    source=row[4],  # file_name
-                ),
-            )
-        return documents
+        return self.retriever(query=query, top_k=top_k, **kwargs)

--- a/larch/search/agents.py
+++ b/larch/search/agents.py
@@ -10,9 +10,9 @@ from langchain.agents import (
     LLMSingleActionAgent,
     Tool,
 )
-from langchain.chat_models import ChatOpenAI
 from langchain.prompts import BaseChatPromptTemplate
 from langchain.schema import AgentAction, AgentFinish, HumanMessage
+from langchain_community.chat_models import ChatOpenAI
 
 from ..structures import Response
 from .engines import AbstractSearchEngine

--- a/larch/search/engines.py
+++ b/larch/search/engines.py
@@ -7,7 +7,6 @@ from typing import List, Optional, Type
 
 import openai
 from langchain.agents import create_sql_agent
-from langchain.agents.agent_toolkits import SQLDatabaseToolkit
 from langchain.agents.agent_toolkits.sql.prompt import SQL_PREFIX
 from langchain.agents.agent_types import AgentType
 from langchain.base_language import BaseLanguageModel
@@ -18,7 +17,8 @@ from langchain.chains.question_answering import load_qa_chain
 from langchain.prompts import ChatPromptTemplate, PromptTemplate
 from langchain.prompts.base import BasePromptTemplate
 from langchain.schema.retriever import BaseRetriever
-from langchain.utilities import SQLDatabase
+from langchain_community.agent_toolkits import SQLDatabaseToolkit
+from langchain_community.utilities import SQLDatabase
 from langchain_openai import ChatOpenAI, OpenAI
 from loguru import logger
 

--- a/larch/search/template_matcher.py
+++ b/larch/search/template_matcher.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from typing import Any, List, Optional
 
 from langchain.base_language import BaseLanguageModel
-from langchain.chat_models import ChatOpenAI
+from langchain_community.chat_models import ChatOpenAI
 from rapidfuzz import fuzz
 
 from ..schema import SQLTemplate

--- a/larch/utils.py
+++ b/larch/utils.py
@@ -14,16 +14,16 @@ except ImportError:
     logger.warning("pandas not installed. Some utilities will not work!")
 
 
-from langchain.document_loaders import (
+from langchain.output_parsers import PydanticOutputParser
+from langchain.pydantic_v1 import BaseModel, ValidationError
+from langchain.schema import OutputParserException
+from langchain.schema.document import Document as LangchainDocument
+from langchain_community.document_loaders import (
     PyPDFLoader,
     TextLoader,
     UnstructuredURLLoader,
     UnstructuredWordDocumentLoader,
 )
-from langchain.output_parsers import PydanticOutputParser
-from langchain.pydantic_v1 import BaseModel, ValidationError
-from langchain.schema import OutputParserException
-from langchain.schema.document import Document as LangchainDocument
 from tqdm import tqdm
 
 from .structures import Document


### PR DESCRIPTION
# Major
- Deprecate `larch.indexing.SinequaDocumentIndexer` in favor of `larch.retrievers.SinequaDocumentRetriever`
  - The new retriever also has all the new changes required for pynequa as well.

Also use langchain_community modules to resolve deprecation warning