### PR TITLE
Bugfix validation error in instructor metadata extractor

### DIFF
--- a/larch/metadata/extractors_openai.py
+++ b/larch/metadata/extractors_openai.py
@@ -107,9 +107,9 @@ class InstructorBasedOpenAIMetadataExtractor(SimpleOpenAIMetadataExtractor):
             message = response.choices[0].message
             result = (
                 self.schema.model_construct(
-                    **json.loads(message["function_call"]["arguments"]),
+                    **json.loads(message.function_call.arguments),
                 )
-                if "function_call" in message
+                if hasattr(message, "function_call")
                 else result
             )
         return result


### PR DESCRIPTION
In the new `openai` client, the `function_call` is an attribute of the `ChatCompletion` object instead of being a key in a `dict`