### PR TITLE
Add better whitelist validator using different matching algorithm

### DIFF
--- a/larch/_base.py
+++ b/larch/_base.py
@@ -9,5 +9,6 @@ class AbstractClass(ABC):
         self.name = name
         self.debug = bool(debug)
 
+    @property
     def __classname__(self) -> str:
         return self.name or self.__class__.__name__

--- a/larch/metadata/extractors_openai.py
+++ b/larch/metadata/extractors_openai.py
@@ -135,7 +135,8 @@ class InstructorBasedOpenAIMetadataExtractor(SimpleOpenAIMetadataExtractor):
                 mode=instructor.function_calls.Mode.FUNCTIONS,
             )
         except ValidationError:
-            logger.warning("Bypassing validation error!")
+            if self.debug:
+                logger.warning("Bypassing validation error!")
             message = response.choices[0].message
             result = (
                 self.schema.model_construct(

--- a/larch/metadata/validators.py
+++ b/larch/metadata/validators.py
@@ -405,6 +405,7 @@ class WhitelistBasedMetadataValidatorWithMatcher(MetadataValidator):
         field_matcher: Optional[Matcher] = None,
         fallback_matcher: Optional[Matcher] = None,
         text_processor: Optional[Union[Callable, TextProcessor]] = None,
+        keys_to_retain: Optional[List[str]] = None,
         unmatched_value: Optional[str] = "original",
         ignore_case: bool = True,
         debug: bool = False,
@@ -414,6 +415,7 @@ class WhitelistBasedMetadataValidatorWithMatcher(MetadataValidator):
         self.field_matcher = field_matcher or ExactMatcher()
         self.fallback_matcher = fallback_matcher
         self.unmatched_value = unmatched_value or None
+        self.keys_to_retain = keys_to_retain or set()
 
         # default: remove non-alpha-numeric values
         self.text_processor = text_processor or NonAlphaNumericRemover(
@@ -498,9 +500,11 @@ class WhitelistBasedMetadataValidatorWithMatcher(MetadataValidator):
             )
 
         best_matches = sorted(best_matches, key=lambda x: x[-1], reverse=True)
-        ret_val = (
-            extracted_value
-            if self.unmatched_value == "original"
-            else self.unmatched_value
-        )
+
+        # if we need to retain the field if unmatched
+        ret_val = None
+        if field_name in self.keys_to_retain or self.unmatched_value == "original":
+            ret_val = extracted_value
+        else:
+            ret_val = self.unmatched_value
         return best_matches[0][0] if best_matches else ret_val

--- a/larch/metadata/validators.py
+++ b/larch/metadata/validators.py
@@ -29,7 +29,7 @@ class SimpleInTextMetadataValidator(MetadataValidator):
 
     Usage
 
-        .. code-blocka: python
+        .. code-block: python
 
             from larch.metadata import InstructorBasedOpenAIMetadataExtractor
             from larch.metadata.validators import SimpleInTextMetadataValidator
@@ -339,12 +339,15 @@ class WhitelistBasedMetadataValidatorWithMatcher(MetadataValidator):
             this will only try to match the list of keys (not their alternatives)
             ```text_processor```: ```Optional[Union[Callable, TextProcessor]]```
                 Text processing that is to be applied.
-                ```unmatched_value```:
-                    Default value for those that don't match to anything on the
-                    whitelist.
-                    - If 'original', then original extracted value is returned.
-                    - Else, whatever is set will be used.
-                    - If None, then those keys are removed by default
+        ```keys_to_retain```: ```Optional[List[str]]```
+            A set of field/key names which shouldn't be removed
+            if they don't match anything on the whitelist.
+        ```unmatched_value```:
+            Default value for those that don't match to anything on the
+            whitelist.
+            - If 'original', then original extracted value is returned.
+            - Else, whatever is set will be used.
+            - If None, then those keys are removed by default
         ```debug```: ```bool```
             Debug mode flag
 

--- a/larch/metadata/validators.py
+++ b/larch/metadata/validators.py
@@ -8,7 +8,7 @@ from rapidfuzz import fuzz
 from rapidfuzz import process as fuzz_process
 from rapidfuzz import utils as fuzz_utils
 
-from ..processors import NonAlphaNumericRemover, TextProcessor
+from ..processors import ExactMatcher, Matcher, NonAlphaNumericRemover, TextProcessor
 from ._base import MetadataValidator
 
 
@@ -181,6 +181,7 @@ class WhitelistBasedMetadataValidator(MetadataValidator):
     def __init__(
         self,
         whitelists: Dict[str, Dict[str, List[str]]],
+        matcher: Optional[Matcher] = None,
         fuzzy_threshold: float = 0.95,
         fuzzy_scorer: Callable = fuzz.WRatio,
         text_processor: Optional[Union[Callable, TextProcessor]] = None,
@@ -189,8 +190,7 @@ class WhitelistBasedMetadataValidator(MetadataValidator):
     ) -> None:
         super().__init__(debug=debug, ignore_case=ignore_case)
         self.whitelists = whitelists
-        self.fuzzy_threshold = fuzzy_threshold
-        self.fuzzy_scorer = fuzzy_scorer or fuzz.WRatio
+        self.matcher = matcher or ExactMatcher()
 
         # default: remove non-alpha-numeric values
         self.text_processor = text_processor or NonAlphaNumericRemover(
@@ -262,13 +262,14 @@ class WhitelistBasedMetadataValidator(MetadataValidator):
             return False
 
         text = text.lower()
+        values = list(map(str.lower, values))
         for val in values:
             if val == text:
                 return True
         return False
 
-    @staticmethod
     def standardize_value(
+        self,
         whitelists: dict,
         field_name: str,
         extracted_value: str,
@@ -303,6 +304,184 @@ class WhitelistBasedMetadataValidator(MetadataValidator):
                 best_matches.append((key, extracted_value, 100.0))
             elif fuzz_matches:
                 best_matches.extend([(key, fm[0], fm[1]) for fm in fuzz_matches])
+        if debug and best_matches:
+            logger.debug(
+                f"extracted value={extracted_value} | field={field_name} | best_matches={best_matches}",
+            )
+
+        best_matches = sorted(best_matches, key=lambda x: x[-1], reverse=True)
+        return best_matches[0][0] if best_matches else extracted_value
+
+
+class WhitelistBasedMetadataValidatorWithMatcher(MetadataValidator):
+    """
+    This validator uses a whitelist to standardize values in a field
+    in the metadata.
+    Each field has a certain value and each value could take on different
+    alternate values during extraction process.
+    This validator recursively traverses the whitelist to figure out
+    (using fuzzy matching) which standard value to inject.
+
+    User is encouraged to use this than `WhitelistBasedMetadataValidator`.
+
+    Args:
+        ```whitelists```: ```Dict[str, Dict[str, List[str]]]```
+            A dictionary mapping for whitelist.
+        ```field_matcher```: ```Matcher```
+            A matcher object to apply the matching algorithm.
+            If not provided, only `larch.processors.ExactMatcher`
+            will be used.
+        ```fallback_matcher```: ```Optional[Matcher]```
+            The fallback approach if per-field matching fails.
+            Instead of going through each key and list of alternatives,
+            this will only try to match the list of keys (not their alternatives)
+            ```text_processor```: ```Optional[Union[Callable, TextProcessor]]```
+                Text processing that is to be applied.
+        ```debug```: ```bool```
+            Debug mode flag
+
+    Note:
+        whitelists is of structure:
+
+            .. code-block: python
+
+                whitelists = {
+                    <field_1>: {
+                    <standard_value_1_str>: [<alternate_value_1>, <alternate_value_2>]
+                    <standard_value_2_str>: [<alternate_value_1>, <alternate_value_2>]
+                    },
+                    <field_2>: {
+                    ...
+                    }
+                }
+
+                whitelists = {'observable': {'aerosols': ['aerosols',
+                   'aerosol optical depth',
+                   'aerosol extinction',
+                   'AOD',
+                   'aerosol concentration',
+                   'pm2.5',
+                   'particulate matter',
+                   'Aerosol vertical distribution']
+                   }
+               }
+
+    Usage:
+
+        .. code-block: python
+
+            from larch.metadata.validators import WhitelistBasedMetadataValidatorWithMatcher
+            from larch.processors import NonAlphaNumericRemover
+            from larch.processors import CombinedMatcher, ExactMatcher, FuzzyMatcher
+
+            metadata = <pydantic_object>
+            # or
+            metadata = <dict>
+
+            validator = WhitelistBasedMetadataValidatorWithMatcher(
+                whitelists=whitelists,
+                field_matcher=CombinedMatcher(
+                    ExactMatcher(),
+                    FuzzyMatcher(threshold=0.95)
+                    )
+                text_processor=NonAlphaNumericRemover(),
+                debug=False,
+            )
+
+            metadata_validated = validator(metadata)
+    """
+
+    def __init__(
+        self,
+        whitelists: Dict[str, Dict[str, List[str]]],
+        field_matcher: Optional[Matcher] = None,
+        fallback_matcher: Optional[Matcher] = None,
+        text_processor: Optional[Union[Callable, TextProcessor]] = None,
+        ignore_case: bool = True,
+        debug: bool = False,
+    ) -> None:
+        super().__init__(debug=debug, ignore_case=ignore_case)
+        self.whitelists = whitelists
+        self.field_matcher = field_matcher or ExactMatcher()
+        self.fallback_matcher = fallback_matcher
+
+        # default: remove non-alpha-numeric values
+        self.text_processor = text_processor or NonAlphaNumericRemover(
+            ignore_case=ignore_case,
+        )
+
+    def _validate(self, metadata: dict, **kwargs) -> dict:
+        return self._recursive_validate(metadata, current_key=None)
+
+    def __call__(self, metadata: dict, **kwargs) -> dict:
+        return self._recursive_validate(metadata, current_key=None)
+
+    def _recursive_validate(
+        self,
+        data: Any,
+        current_key: str = None,
+    ) -> Any:
+        """
+        This recursively traverses the dictionary to do the standardization
+        """
+        # check for dict
+        if isinstance(data, dict):
+            validated_dict = {}
+            for key, value in data.items():
+                validated_value = self._recursive_validate(value, key)
+                if validated_value:
+                    validated_dict[key] = validated_value
+            return validated_dict
+
+        # if list, recursively apply same thing to each item
+        elif isinstance(data, list):
+            res = map(
+                lambda item: self._recursive_validate(item, current_key),
+                data,
+            )
+            res = filter(None, res)
+            return list(res)
+
+        # final leaf/node is a text value
+        elif isinstance(data, (str, int, float)) and current_key is not None:
+            return self.standardize_value(
+                self.whitelists,
+                current_key,
+                data,
+                processor=self.text_processor,
+                debug=self.debug,
+            )
+
+        return data
+
+    def standardize_value(
+        self,
+        whitelists: dict,
+        field_name: str,
+        extracted_value: str,
+        processor: Callable = None,
+        debug: bool = False,
+    ) -> str:
+        field_dct = whitelists.get(field_name, {}).copy()
+        if not field_dct:
+            return extracted_value
+
+        extracted_value_processed = (
+            processor(extracted_value) if processor is not None else extracted_value
+        )
+
+        best_matches = []
+        for key, values in field_dct.items():
+            values = list(map(processor, values))
+            matches = self.field_matcher(extracted_value_processed, values)
+            if matches:
+                best_matches.extend([(key, m[0], m[1]) for m in matches])
+
+        # use fallback only if there are no matches from `field_matcher`
+        if not best_matches and self.fallback_matcher:
+            f_match = self.fallback_matcher(extracted_value, list(field_dct.keys()))
+            best_matches.extend([(m[0], m[0], m[1]) for m in f_match])
+
         if debug and best_matches:
             logger.debug(
                 f"extracted value={extracted_value} | field={field_name} | best_matches={best_matches}",

--- a/larch/processors.py
+++ b/larch/processors.py
@@ -1,14 +1,24 @@
 #!/usr/bin/env python3
 
+import copy
 import re
 from abc import ABC, abstractmethod
+from typing import List, Literal, Optional, Tuple
 
 from loguru import logger
+from openai import BadRequestError
+from pydantic import BaseModel, Field, create_model
+from rapidfuzz import fuzz
+from rapidfuzz import process as fuzz_process
 
 try:
     import spacy
 except ImportError:
     logger.warning("spacy is not installed. Can't use `larch.processors.PIIRemover`")
+
+
+from ._base import AbstractClass
+from .metadata._base import AbstractMetadataExtractor
 
 
 class TextProcessor(ABC):
@@ -102,6 +112,248 @@ class TextProcessingPipeline(TextProcessor):
         for processor in self.processors:
             text = processor(text)
         return text
+
+
+class Matcher(AbstractClass):
+    """
+    A component to match text with a list of text.
+    """
+
+    def __init__(self, debug: bool = False, ignore_case: bool = True) -> None:
+        super().__init__(debug=debug)
+        self.ignore_case = ignore_case
+
+    @abstractmethod
+    def match(self, text: str, values: List[str]) -> List[Tuple[str, float]]:
+        """
+        Args:
+            ```text```: ```str```
+                Text that is to be matched
+            ```values```: ```List[str]```
+                A list of text to be matcheda against
+
+        Returns:
+            ```List[Tuple[str, float]]```
+                A list of tuple that represent best matches.
+                - First element of tuple is the matched text from the list of
+                values
+                - Second element of tuple is the matching score
+        """
+        raise NotImplementedError()
+
+    def __call__(self, *args, **kwargs) -> List[tuple]:
+        return self.match(*args, **kwargs)
+
+
+class ExactMatcher(Matcher):
+    """
+    Use this if you want to match the texts exactly.
+    (x==y)
+    """
+
+    def match(self, text: str, values: List[str]) -> List[Tuple[str, float]]:
+        """
+        Args:
+            ```text```: ```str```
+                Text that is to be matched
+            ```values```: ```List[str]```
+                A list of text to be matcheda against
+
+        Returns:
+            ```List[Tuple[str, float]]```
+                A list of tuple that represent best matches.
+                - First element of tuple is the matched text from the list of
+                values
+                - Second element of tuple is the matching score
+        """
+        text_org = text[:]
+        if self.ignore_case:
+            text = text.lower()
+            values = list(map(str.lower, values))
+        for val in values:
+            if val == text:
+                return [(text_org, 100.0)]
+        return []
+
+
+class FuzzyMatcher(Matcher):
+    """
+    This matches the text against the list of texts using fuzzy-matching.
+    """
+
+    def __init__(
+        self,
+        scorer=fuzz.WRatio,
+        threshold: float = 0.95,
+        ignore_case: bool = True,
+    ) -> None:
+        super().__init__(ignore_case=ignore_case)
+        self.threshold = threshold
+        self.scorer = fuzz.WRatio
+        self.ignore_case = ignore_case
+
+    def match(self, text: str, values: List[str]) -> List[tuple]:
+        """
+        Args:
+            ```text```: ```str```
+                Text that is to be matched
+            ```values```: ```List[str]```
+                A list of text to be matcheda against
+
+        Returns:
+            ```List[Tuple[str, float]]```
+                A list of tuple that represent best matches.
+                - First element of tuple is the matched text from the list of
+                values
+                - Second element of tuple is the matching score
+        """
+        if self.ignore_case:
+            text = text.lower()
+            values = list(map(str.lower, values))
+
+        cutoff = self.threshold * 100
+        matches = fuzz_process.extract(
+            text,
+            values,
+            scorer=self.scorer,
+            score_cutoff=cutoff,
+        )
+        return list(map(lambda x: (x[0], x[1]), matches))
+
+
+class LLMMatcher(Matcher):
+    """
+    This is a LLM-based matcher that makes use of
+    ```larch.metadata.AbstractMetadataExtractor```.
+
+    The matching is treated as a metadata extraction problem via LLM.
+
+    This creates a pydantic schema dynamically (at runtime) using
+    provided `text` and `values`. Values represent the `whitelist` field
+    of the schema and text is passed to the extractor to extract the matching
+    string.
+
+    Note:
+        - Chances of not returning exactly the string present in the list
+    """
+
+    _PROMPT_WHITELIST = (
+        "Value that is selected. If no value matches, just return empty string."
+    )
+
+    def __init__(
+        self,
+        extractor: AbstractMetadataExtractor,
+        prompt_whitelist: Optional[str] = None,
+        ignore_case: bool = False,
+    ) -> None:
+        """
+        Args:
+            ```extractor```: ```AbstractMetadataExtractor```
+                Any metadata extractor within larch
+            ```prompt_whitelist```: ```Optional[str]```
+                Prompt that is use to descripe the `whitelist` field
+                for the schema
+        """
+        super().__init__(ignore_case=ignore_case)
+        self.extractor = extractor
+        self.extractor.schema = None
+        self.prompt_whitelist = prompt_whitelist or LLMMatcher._PROMPT_WHITELIST
+
+    @property
+    def schema(self) -> Optional[BaseModel]:
+        return self.extractor.schema
+
+    def match(self, text: str, values: List[str]) -> List[Tuple[str, float]]:
+        """
+        Args:
+            ```text```: ```str```
+                Text that is to be matched
+            ```values```: ```List[str]```
+                A list of text to be matcheda against
+
+        Returns:
+            ```List[Tuple[str, float]]```
+                A list of tuple that represent best matches.
+                - First element of tuple is the matched text from the list of
+                values
+                - Second element of tuple is the matching score
+        """
+        text_org = text[:]
+        if self.ignore_case:
+            text = text.lower()
+            values = list(map(str.lower, values))
+
+        # copy and modify schema at runtime
+        extractor = copy.copy(self.extractor)
+
+        extractor.schema = create_model(
+            "_WhitelistSelector",
+            whitelist=(
+                Literal[tuple(values)],
+                Field(
+                    ...,
+                    description=self.prompt_whitelist,
+                ),
+            ),
+            score=(
+                float,
+                Field(
+                    ...,
+                    ge=0,
+                    le=100,
+                    description="Match score in range [0, 100]. If no match, return 0.0",
+                ),
+            ),
+        )
+        res = []
+        try:
+            match = extractor(text)
+            if match.whitelist and match.whitelist != text:
+                # Rant: Don't trust LLM scores out-of-box
+                score = getattr(match, "score", 0.0)
+                res = [(match.whitelist, score)]
+        except (BadRequestError, AttributeError):
+            res = []
+
+        # set to initial None because schema is built at runtime here
+        self.extractor.schema = None
+        return res
+
+
+class CombinedMatcher(Matcher):
+    """
+    This encapsulates all the matcher object in series,
+    where we run each matching algorithm in waterfall,
+    and the first one to match will be the final result.
+
+    This is used when we want to combine all the matching algorithm,
+    like a fallback approach.
+    """
+
+    def __init__(self, *matchers: Matcher) -> None:
+        self.matchers = matchers
+
+    def match(self, text: str, values: List[str]) -> List[Tuple[str, float]]:
+        """
+        Args:
+            ```text```: ```str```
+                Text that is to be matched
+            ```values```: ```List[str]```
+                A list of text to be matcheda against
+
+        Returns:
+            ```List[Tuple[str, float]]```
+                A list of tuple that represent best matches.
+                - First element of tuple is the matched text from the list of
+                values
+                - Second element of tuple is the matching score
+        """
+        for matcher in self.matchers:
+            matches = matcher(text, values)
+            if matches:
+                return matches
+        return []
 
 
 def main():

--- a/larch/processors.py
+++ b/larch/processors.py
@@ -207,18 +207,13 @@ class FuzzyMatcher(Matcher):
                 values
                 - Second element of tuple is the matching score
         """
-        if self.ignore_case:
-            text = text.lower()
-            values = list(map(str.lower, values))
-
-        cutoff = self.threshold * 100
         matches = fuzz_process.extract(
-            text,
-            values,
+            text.lower() if self.ignore_case else text,
+            list(map(str.lower, values)) if self.ignore_case else values,
             scorer=self.scorer,
-            score_cutoff=cutoff,
+            score_cutoff=self.threshold * 100,
         )
-        return list(map(lambda x: (x[0], x[1]), matches))
+        return list(map(lambda x: (values[x[2]], x[1]), matches))
 
 
 class LLMMatcher(Matcher):


### PR DESCRIPTION
# Major Changes

This PR introduces a few new components that make it easier to validate metadata based on the whitelist

- `larch.processors.Matcher` component is added that is used for matching text against a list of texts
  - `larch.processors.ExactMatcher` is used for exact match
  - `larch.processors.FuzzyMatcher` is used for using fuzzy match-based algorithm
  - `larch.processors.LLMMatcher` uses LLM-based matching
  - `larch.processors.CombinedMatcher` can be used to combine multiple matchers in waterfall fashion

- `larch.metadata.validators.WhitelistBasedMetadataValidatorWithMatcher` is added that makes use of available `Matcher` components to directly compare the texts.
  -  `WhitelistBasedMetadataValidatorWithMatcher.field_matcher` is used when we want the algorithm that tries to map (for a given field) to a specific standard value based on available alternate values
  - `WhitelistBasedMetadataValidatorWithMatcher.fallback_matcher` is used when everything fails and the algorithm tries to map the extraction based only on standard values available (in this mode, alternate values aren't considered)

# Minor Changes
- bugfix `larch._base.AbstractClass.__classname__` to use `@property`
- Change `WhitelistBasedMetadataValidatorWithMatcher.standardize_values` and `WhitelistBasedMetadataValidator.standardize_values` from static methods to object-level methods (can access object attributes now)

---

# Usages

Usages can be seen in the the docstring of the components. But here's the tentative ones


```python
from openai import OpenAI

from larch.metadata import InstructorBasedOpenAIMetadataExtractor
from larch.metadata.validators import WhitelistBasedMetadataValidatorWithMatcher

from larch.processors import (
    CombinedMatcher,    
    ExactMatcher,
    FuzzyMatcher,
    CombinedMatcher,
    LLMMatcher
)

from larch.utils import load_whitelist

matcher = ExactMatcher()
match = matcher(
    text="paradox",
    values=["para", "Paradox"]
) # Output [('Paradox', 100.0)]



matcher = FuzzyMatcher()
match = matcher(
    text="parado",
    values=["para", "Paradox"]
) # [('Paradox', 92.3076923076923), ('para', 90.0)]

matcher = LLMMatcher(
    InstructorBasedOpenAIMetadataExtractor(schema=None, openai_client=OpenAI(), model="gpt-3.5-turbo", debug=False),
    debug=True,
)
match = matcher(
   text="prdx",
    values=["para", "Paradox"]
) # Output: [('Paradox', 100.0)]


whitelist_map = load_whitelist(<path_to_excel_file>)
whitelist_map = whitelists={"address": {"Huntsville": ["Huntsville", "hunsville", "huntsvil"]}},

metadata = dict(address="hunsvllle")
metadata_validated = WhitelistBasedMetadataValidatorWithMatcher(
    whitelists=whitelist_map,
    field_matcher=CombinedMatcher(ExactMatcher(), FuzzyMatcher()),
    fallback_matcher=LLMMatcher(
        InstructorBasedOpenAIMetadataExtractor(
            schema=None,
            openai_client=OpenAI(), model="gpt-3.5-turbo",
            debug=True
        ),
        debug=True,
    ),
    unmatched_value=None # If set to `None`, unmatched keys will be removed
)(metadata) # Output: {"address": "Huntsville"}
```